### PR TITLE
feat: fashion-cbf service

### DIFF
--- a/jenkins/ecs_fashion_cbf.sh
+++ b/jenkins/ecs_fashion_cbf.sh
@@ -12,7 +12,7 @@ export OUTPUT_DIR
 source ~/anaconda3/etc/profile.d/conda.sh
 conda activate fashion-cbf-env
 bentoml build -f $OUTPUT_DIR/bentofile.yaml
-bentoml containerize product_recommendation:latest -t 210651441624.dkr.ecr.ap-northeast-2.amazonaws.com/fashion-cbf:latest
+bentoml containerize fashion-cbf:latest -t 210651441624.dkr.ecr.ap-northeast-2.amazonaws.com/fashion-cbf:latest
 
 aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 210651441624.dkr.ecr.ap-northeast-2.amazonaws.com
 docker push 210651441624.dkr.ecr.ap-northeast-2.amazonaws.com/fashion-cbf:latest

--- a/serving/bentoml/utils/feature.py
+++ b/serving/bentoml/utils/feature.py
@@ -37,3 +37,7 @@ class Product_Output(BaseModel):
 
 class UserId(BaseModel):
     user_id: int = 1
+
+
+class NewProductId(BaseModel):
+    product_ids: List[int] = [1, 2, 3]

--- a/serving/bentoml/utils/rds.py
+++ b/serving/bentoml/utils/rds.py
@@ -16,13 +16,23 @@ def connect(host, user, password, db, port):
     return rds
 
 
-def load_ProductImageGender(cursor):
-    query = f"""
-        SELECT P.PRODUCT_ID AS PRODUCT_ID, I.URL AS URL, P.GENDER AS GENDER
-        FROM PRODUCT P
-        INNER JOIN (SELECT URL, PRODUCT_ID FROM IMAGEPATH WHERE THUMBNAIL = 1) I
-        ON P.PRODUCT_ID = I.PRODUCT_ID;
-    """
+def load_ProductImageGender(cursor, product_ids):
+    if product_ids == []:
+        query = f"""
+            SELECT P.PRODUCT_ID AS PRODUCT_ID, I.URL AS URL, P.GENDER AS GENDER
+            FROM PRODUCT P
+            INNER JOIN (SELECT URL, PRODUCT_ID FROM IMAGEPATH WHERE THUMBNAIL = 1) I
+            ON P.PRODUCT_ID = I.PRODUCT_ID;
+        """
+    else:
+        product_ids = str(tuple(product_ids)).replace(",)", ")")
+        query = f"""
+            SELECT P.PRODUCT_ID AS PRODUCT_ID, I.URL AS URL, P.GENDER AS GENDER
+            FROM PRODUCT P
+            INNER JOIN (SELECT URL, PRODUCT_ID FROM IMAGEPATH WHERE THUMBNAIL = 1) I
+            ON P.PRODUCT_ID = I.PRODUCT_ID
+            WHERE P.PRODUCT_ID IN {tuple(product_ids)};
+        """
     cursor.execute(query)
     products = cursor.fetchall()
     products_df = pd.DataFrame(products)


### PR DESCRIPTION
# fashion-cbf /product_encode
## 이전
1. product_encode에 request를 보내면 전제 상품 DB의 이미지를 임베딩
2. vectorDB의 collection을 삭제하고 다시 만들고 임베딩 벡터들을 저장 
## 바뀐부분
1. request에 새롭게 추가된 상품의 id 들을 받음
2. 해당 상품들의 이미지만 불러와 임베딩
3. 임베딩 벡터를 vectorDB에 추가