### PR TITLE
fix: fashion_cbf

### DIFF
--- a/serving/bentoml/utils/feature.py
+++ b/serving/bentoml/utils/feature.py
@@ -32,7 +32,7 @@ class Product_Input(BaseModel):
 
 
 class Product_Output(BaseModel):
-    product_ids: List[int]
+    product_ids: List[int] = [146, 200, 267, 6, 345]
 
 
 class UserId(BaseModel):

--- a/serving/bentoml/utils/s3.py
+++ b/serving/bentoml/utils/s3.py
@@ -32,7 +32,6 @@ async def load_img_(url, client, preprocess):
     try:
         return preprocess(Image.open(BytesIO(obj)))
     except:
-        print(obj)
         raise Exception("Image open error")
 
 

--- a/serving/bentoml/utils/utils.py
+++ b/serving/bentoml/utils/utils.py
@@ -1,0 +1,13 @@
+import requests
+import re
+
+
+def local_check():
+    req = requests.get("http://ipconfig.kr")
+    host_ip = re.search(r"IP Address : (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})", req.text)[
+        1
+    ]
+    if host_ip == "220.72.106.46":
+        return True
+    else:
+        return False


### PR DESCRIPTION
# fashion_cbf service 버그 수정
## timeout error
- product_encode 전체 상품으로 했을 때 timeout 발생
  => 로드밸런서의 유휴 제한 시간을 60초 -> 120초로 바꾸니까 해결
</br>

## 로컬pc와 aws의 vectorDB 접근 차이
- 로컬에서 vectorDB에 접근할 땐 vectorDB의 ec2 public ip를 사용
- vectorDB의 인바운드 규칙의 source를 fashion_cbf service의 보안그룹으로 허용
  => 이러면 vectorDB에 접근하기 위해선 ec2 private ip를 사용해야함
  => 로컬에서랑 aws 서비스시의 코드 차이 발생
- local check 부분을 추가