### PR TITLE
36 hyperparameter tuning for product encode

### DIFF
--- a/configs/bentoml_config.yaml
+++ b/configs/bentoml_config.yaml
@@ -1,0 +1,4 @@
+api_server:
+  traffic:
+    timeout: 120
+    max_concurrency: 50

--- a/configs/bentoml_config.yaml
+++ b/configs/bentoml_config.yaml
@@ -1,4 +1,4 @@
 api_server:
   traffic:
-    timeout: 120
+    timeout: 500
     max_concurrency: 50

--- a/configs/model/v1.yaml
+++ b/configs/model/v1.yaml
@@ -21,3 +21,4 @@ product_encode:
   _target_: src.models.lightning_modules.ProductModule
   learning_rate: 1e-4
   bbox_loss_weight: 1.0
+  embedding_dim: 64

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -7,4 +7,4 @@ defaults:
   - preprocess: v1.yaml
   - hydra: default.yaml
 optimizer.config.learning_rate:
-train: human_size
+train: product_encode

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -6,5 +6,4 @@ defaults:
   - paths: default.yaml
   - preprocess: v1.yaml
   - hydra: default.yaml
-optimizer.config.learning_rate:
 train: product_encode

--- a/extras/constant.py
+++ b/extras/constant.py
@@ -55,3 +55,11 @@ BUCKET_NAME_HUMAN = "fittering-measurements-images"
 S3_URL_HUMAN = "https://fittering-measurements-images.s3.ap-northeast-2.amazonaws.com"
 
 BUCKET_NAME_PRODUCT = "fittering-crawling-image"
+
+
+# ------------------------ milvus ------------------------
+# MILVUS_COLLECTION_NAME = "image_embedding_collection"
+MILVUS_COLLECTION_NAME = "image_embedding_collection_test"
+MILVUS_PRIVATE_HOST = "172.31.3.122"
+MILVUS_PUBLIC_HOST = "13.125.214.45"
+MILVUS_PORT = "19530"

--- a/extras/constant.py
+++ b/extras/constant.py
@@ -54,12 +54,13 @@ occlude_box_dim = 48
 BUCKET_NAME_HUMAN = "fittering-measurements-images"
 S3_URL_HUMAN = "https://fittering-measurements-images.s3.ap-northeast-2.amazonaws.com"
 
-BUCKET_NAME_PRODUCT = "fittering-crawling-image"
+S3_BUCKET_NAME_PRODUCT = "fittering-images-bucket"
+S3_BUCKET_PATH_PRODUCT = "images/"
 
 
 # ------------------------ milvus ------------------------
-# MILVUS_COLLECTION_NAME = "image_embedding_collection"
-MILVUS_COLLECTION_NAME = "image_embedding_collection_test"
+MILVUS_COLLECTION_NAME = "image_embedding_collection"
+# MILVUS_COLLECTION_NAME = "image_embedding_collection_test"
 MILVUS_PRIVATE_HOST = "172.31.3.122"
 MILVUS_PUBLIC_HOST = "13.125.214.45"
 MILVUS_PORT = "19530"

--- a/serving/bentoml/service_fashion_cbf.py
+++ b/serving/bentoml/service_fashion_cbf.py
@@ -11,6 +11,7 @@ from serving.bentoml.utils import feature, s3, rds, vector_db, bento_svc, utils
 root_dir = pyrootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
 from serving.bentoml import rds_info
+from extras.constant import *
 
 
 (
@@ -30,9 +31,9 @@ def product_encode(input: feature.NewProductId) -> Dict[str, Any]:
         port=rds_info.port,
     )
     if utils.local_check():
-        vector_db.connect(host="13.125.214.45", port="19530")
+        vector_db.connect(host=MILVUS_PUBLIC_HOST, port=MILVUS_PORT)
     else:
-        vector_db.connect(host="172.31.3.122", port="19530")
+        vector_db.connect(host=MILVUS_PRIVATE_HOST, port=MILVUS_PORT)
 
     input = input.dict()
     product_ids = input["product_ids"]
@@ -40,21 +41,22 @@ def product_encode(input: feature.NewProductId) -> Dict[str, Any]:
     cursor = rds_conn.cursor()
     products_df = rds.load_ProductImageGender(cursor, product_ids)
 
-    imgs_tensor = asyncio.run(
+    imgs_tensor, nframes = asyncio.run(
         s3.load_img(products_df["URL"].to_list(), product_encode_preprocess)
     )
     imgs_encoded = product_encode_runner.run(imgs_tensor)
+    imgs_encoded = utils.mean_nframe_encoded(imgs_encoded, nframes)
 
-    if vector_db.exist_collection("image_embedding_collection"):
+    if vector_db.exist_collection(MILVUS_COLLECTION_NAME):
         vector_db.add_vector(
-            collection_name="image_embedding_collection",
+            collection_name=MILVUS_COLLECTION_NAME,
             embedded=imgs_encoded.numpy(),
             product_id=products_df["PRODUCT_ID"].to_list(),
             gender=products_df["GENDER"].to_list(),
         )
     else:
         vector_db.save_collection(
-            collection_name="image_embedding_collection",
+            collection_name=MILVUS_COLLECTION_NAME,
             embedded=imgs_encoded.numpy(),
             product_id=products_df["PRODUCT_ID"].to_list(),
             gender=products_df["GENDER"].to_list(),
@@ -85,13 +87,13 @@ def fashion_cbf(input: feature.Product_Input) -> feature.Product_Output:
         port=rds_info.port,
     )
     if utils.local_check():
-        vector_db.connect(host="13.125.214.45", port="19530")
+        vector_db.connect(host=MILVUS_PUBLIC_HOST, port=MILVUS_PORT)
     else:
-        vector_db.connect(host="172.31.3.122", port="19530")
+        vector_db.connect(host=MILVUS_PRIVATE_HOST, port=MILVUS_PORT)
 
     if product_ids:
         recommendation_products = vector_db.search_vector(
-            "image_embedding_collection",
+            MILVUS_COLLECTION_NAME,
             product_ids,
             product_gender,
             top_k,

--- a/serving/bentoml/service_human_size.py
+++ b/serving/bentoml/service_human_size.py
@@ -119,11 +119,11 @@ def human_size(input: feature.User) -> feature.UserSize:
 
     return {
         "height": pred[0][0],
-        "chest_circumference": pred[0][1],
-        "waist_circumference": pred[0][2],
-        "hip_circumference": pred[0][3],
-        "thigh_left_circumference": pred[0][4],
-        "arm_left_length": pred[0][5],
-        "inside_leg_height": pred[0][6],
-        "shoulder_breadth": pred[0][7],
+        "chest": pred[0][1],
+        "waist": pred[0][2],
+        "hip": pred[0][3],
+        "thigh": pred[0][4],
+        "arm": pred[0][5],
+        "leg": pred[0][6],
+        "shoulder": pred[0][7],
     }

--- a/serving/bentoml/utils/bento_svc.py
+++ b/serving/bentoml/utils/bento_svc.py
@@ -36,9 +36,10 @@ def human_size_svc(root_dir):
 def product_recommendation_svc(root_dir):
     output_dir = os.environ["OUTPUT_DIR"]
     cfg = OmegaConf.load(os.path.join(root_dir, output_dir, ".hydra/config.yaml"))
+    bentofile_yml = OmegaConf.load(os.path.join(root_dir, output_dir, "bentofile.yaml"))
 
     product_encode_preprocess = hydra.utils.instantiate(cfg.preprocess.product_encode)
-    product_encode_runner = bentoml.pytorch.get("product_encode:latest").to_runner()
+    product_encode_runner = bentoml.pytorch.get(bentofile_yml.models[0]).to_runner()
     # del sys.modules["prometheus_client"]
 
     svc = bentoml.Service(

--- a/serving/bentoml/utils/feature.py
+++ b/serving/bentoml/utils/feature.py
@@ -17,13 +17,13 @@ class User(BaseModel):
 
 class UserSize(BaseModel):
     height: float
-    chest_circumference: float
-    waist_circumference: float
-    hip_circumference: float
-    thigh_left_circumference: float
-    arm_left_length: float
-    inside_leg_height: float
-    shoulder_breadth: float
+    chest: float
+    waist: float
+    hip: float
+    thigh: float
+    arm: float
+    leg: float
+    shoulder: float
 
 
 class Product_Input(BaseModel):

--- a/serving/bentoml/utils/rds.py
+++ b/serving/bentoml/utils/rds.py
@@ -25,13 +25,14 @@ def load_ProductImageGender(cursor, product_ids):
             ON P.PRODUCT_ID = I.PRODUCT_ID;
         """
     else:
-        product_ids = str(tuple(product_ids)).replace(",)", ")")
+        product_ids = tuple(product_ids + [0])
+
         query = f"""
             SELECT P.PRODUCT_ID AS PRODUCT_ID, I.URL AS URL, P.GENDER AS GENDER
             FROM PRODUCT P
             INNER JOIN (SELECT URL, PRODUCT_ID FROM IMAGEPATH WHERE THUMBNAIL = 1) I
             ON P.PRODUCT_ID = I.PRODUCT_ID
-            WHERE P.PRODUCT_ID IN {tuple(product_ids)};
+            WHERE P.PRODUCT_ID IN {product_ids};
         """
     cursor.execute(query)
     products = cursor.fetchall()

--- a/serving/bentoml/utils/s3.py
+++ b/serving/bentoml/utils/s3.py
@@ -28,7 +28,10 @@ def connect(s3_access_key_path):
 
 
 async def load_img_(url, client, preprocess):
-    response = await client.get_object(Bucket=constant.BUCKET_NAME_PRODUCT, Key=url)
+    response = await client.get_object(
+        Bucket=constant.S3_BUCKET_NAME_PRODUCT,
+        Key=constant.S3_BUCKET_PATH_PRODUCT + url,
+    )
     obj = await response["Body"].read()
     try:
         image_obj = Image.open(BytesIO(obj))

--- a/serving/bentoml/utils/utils.py
+++ b/serving/bentoml/utils/utils.py
@@ -1,5 +1,6 @@
 import requests
 import re
+import torch
 
 
 def local_check():
@@ -11,3 +12,15 @@ def local_check():
         return True
     else:
         return False
+
+
+def mean_nframe_encoded(imgs_encoded, nframes):
+    new_imgs_encoded = []
+    start_idx = 0
+    for nframe in nframes:
+        end_idx = start_idx + nframe
+        sub_tensor = imgs_encoded[start_idx:end_idx]
+        mean_tensor = torch.mean(sub_tensor, dim=0, keepdim=True)
+        new_imgs_encoded.append(mean_tensor)
+        start_idx = end_idx
+    return torch.cat(new_imgs_encoded, dim=0)

--- a/serving/bentoml/utils/vector_db.py
+++ b/serving/bentoml/utils/vector_db.py
@@ -28,7 +28,7 @@ def delete_collection(collection_name):
 
 
 def add_vector(collection_name, embedded, product_id, gender):
-    image_embedding_collection = Collection("image_embedding_collection")
+    image_embedding_collection = Collection(collection_name)
     image_embedding_collection.load()
 
     entities = [

--- a/serving/bentoml/utils/vector_db.py
+++ b/serving/bentoml/utils/vector_db.py
@@ -30,7 +30,6 @@ def delete_collection(collection_name):
 def add_vector(collection_name, embedded, product_id, gender):
     image_embedding_collection = Collection(collection_name)
     image_embedding_collection.load()
-
     entities = [
         product_id,
         gender,

--- a/serving/bentoml/utils/vector_db.py
+++ b/serving/bentoml/utils/vector_db.py
@@ -1,4 +1,5 @@
 import random
+import pymilvus
 from pymilvus import (
     connections,
     utility,
@@ -35,8 +36,13 @@ def add_vector(collection_name, embedded, product_id, gender):
         gender,
         embedded,
     ]
-    image_embedding_collection.insert(entities)
-    image_embedding_collection.flush()
+    try:
+        image_embedding_collection.insert(entities)
+        image_embedding_collection.flush()
+
+    except pymilvus.exceptions.ParamError:
+        delete_collection(collection_name)
+        save_collection(collection_name, embedded, product_id, gender)
 
 
 def save_collection(collection_name, embedded, product_id, gender):
@@ -48,7 +54,9 @@ def save_collection(collection_name, embedded, product_id, gender):
             auto_id=False,
         ),
         FieldSchema(name="gender", dtype=DataType.VARCHAR, max_length=1),
-        FieldSchema(name="embeddings", dtype=DataType.FLOAT_VECTOR, dim=64),
+        FieldSchema(
+            name="embeddings", dtype=DataType.FLOAT_VECTOR, dim=embedded.shape[1]
+        ),
     ]
     schema = CollectionSchema(fields, "product_image_vector")
 

--- a/shell_script/local_fashion_cbf.sh
+++ b/shell_script/local_fashion_cbf.sh
@@ -10,4 +10,4 @@ fi
 export OUTPUT_DIR
 source ~/anaconda3/etc/profile.d/conda.sh
 conda activate fashion-cbf-env
-bentoml serve serving.bentoml.service_fashion_cbf:svc --development --reload
+BENTOML_CONFIG=./configs/bentoml_config.yaml bentoml serve serving.bentoml.service_fashion_cbf:svc --development --reload

--- a/shell_script/local_fashion_cbf.sh
+++ b/shell_script/local_fashion_cbf.sh
@@ -10,4 +10,4 @@ fi
 export OUTPUT_DIR
 source ~/anaconda3/etc/profile.d/conda.sh
 conda activate fashion-cbf-env
-BENTOML_CONFIG=./configs/bentoml_config.yaml bentoml serve serving.bentoml.service_fashion_cbf:svc --development --reload
+BENTOML_CONFIG=./configs/bentoml_config.yaml bentoml serve serving.bentoml.service_fashion_cbf:svc --development

--- a/shell_script/train_best_sweep.sh
+++ b/shell_script/train_best_sweep.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "경로를 입력하세요: "
+read path
+
+python src/train.py --config-path $path/.hydra --config-name config trainer.product_encode.max_epochs=10

--- a/src/data/datamodule.py
+++ b/src/data/datamodule.py
@@ -52,7 +52,6 @@ class DataModule(pl.LightningDataModule):
         self.shuffle = shuffle
 
         self.transform = transform
-        print()
 
     def prepare_data(self):
         pass

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -212,14 +212,18 @@ class AutoEncoder(nn.Module):
 
 
 class ProductImageEncode(nn.Module):
-    def __init__(self):
+    def __init__(self, embedding_dim):
         super().__init__()
         base = efficientnet.from_name("efficientnet-b0")
         base._blocks = nn.Sequential(*base._blocks)
 
         layers = list(base.children())[:-6]
-        layers += [nn.Conv2d(320, 64, kernel_size=1, stride=1, padding=0, bias=False)]
-        layers += [nn.BatchNorm2d(64)]
+        layers += [
+            nn.Conv2d(
+                320, embedding_dim, kernel_size=1, stride=1, padding=0, bias=False
+            )
+        ]
+        layers += [nn.BatchNorm2d(embedding_dim)]
         layers += [nn.AdaptiveAvgPool2d(1)]
         self.net = nn.Sequential(*layers)
 
@@ -228,11 +232,11 @@ class ProductImageEncode(nn.Module):
 
 
 class ProductClassifyBox(nn.Module):
-    def __init__(self):
+    def __init__(self, embedding_dim):
         super().__init__()
-        self.encoder = ProductImageEncode()
-        self.fc_classify = nn.Linear(64, 50)
-        self.fc_box = nn.Linear(64, 4)
+        self.encoder = ProductImageEncode(embedding_dim=embedding_dim)
+        self.fc_classify = nn.Linear(embedding_dim, 50)
+        self.fc_box = nn.Linear(embedding_dim, 4)
 
     def forward(self, x):
         x = self.encoder(x)
@@ -242,5 +246,7 @@ class ProductClassifyBox(nn.Module):
 if __name__ == "__main__":
     from torchinfo import summary
 
-    model = AutoEncoder(input_shape=[512, 512], nblocks=5, filters=32, latent_dim=256)
-    summary(model, (16, 1, 512, 512))
+    # model = AutoEncoder(input_shape=[512, 512], nblocks=5, filters=32, latent_dim=256)
+    # summary(model, (16, 1, 512, 512))
+    model = ProductImageEncode()
+    summary(model, (16, 3, 256, 256))

--- a/src/train.py
+++ b/src/train.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import argparse
 import torch
 import hydra
@@ -81,4 +82,5 @@ def main(cfg: DictConfig):
 
 
 if __name__ == "__main__":
+    sys.argv.append("hydra.run.dir=./outputs/${now:%Y-%m-%d_%H-%M-%S}")
     main()

--- a/wandb_sweep/sweep_product_encode.sh
+++ b/wandb_sweep/sweep_product_encode.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+export WANDB_DIR=./wandb_sweep/
+  
+wandb sweep wandb_sweep/sweep_product_encode.yaml > temp_output.txt 2>&1
+
+last_line=$(tail -n 1 temp_output.txt)
+rm temp_output.txt
+RUN=$(echo "$last_line" | awk -F':' '{print $NF}')
+$RUN

--- a/wandb_sweep/sweep_product_encode.yaml
+++ b/wandb_sweep/sweep_product_encode.yaml
@@ -1,10 +1,33 @@
-product_encode:
-  method: bayes
-  name: sweep
-  metric:
-    goal: minimize
-    name: test_loss
-  parameters:
-    model.product_encode.learning_rate:
-      max: 1e-3
-      min: 1e-5
+program: src/train.py
+entity: "sinjy1203"
+project: "product_encode_sweep"
+method: bayes
+run_cap: 20
+metric:
+  goal: minimize
+  name: val_loss
+early_terminate:
+  type: hyperband
+  min_iter: 3
+parameters:
+  train:
+    value: "product_encode"
+  trainer.product_encode.max_epochs:
+    value: 5
+  model.product_encode.learning_rate:
+    max: 0.001
+    min: 0.00001
+  model.product_encode.bbox_loss_weight:
+    min: 0.1
+    max: 0.9
+  model.product_encode.embedding_dim:
+    values: [32, 64, 128, 256, 512]
+  preprocess.product_encode.transforms.1.size:
+    values: [[64, 64], [128, 128], [256, 256], [512, 512]]
+    
+command:
+- ${env}
+- ${interpreter}
+- ${program}
+- ${args_no_hyphens}
+    

--- a/wandb_sweep/sweep_product_encode.yaml
+++ b/wandb_sweep/sweep_product_encode.yaml
@@ -4,8 +4,8 @@ project: "product_encode_sweep"
 method: bayes
 run_cap: 20
 metric:
-  goal: minimize
-  name: val_loss
+  goal: maxmize
+  name: val_acc
 early_terminate:
   type: hyperband
   min_iter: 3


### PR DESCRIPTION
# hyperparameter tuning for product encode
- wandb sweep을 활용
- 상품 이미지를 임베딩하는 모델의 하이퍼파라미터 최적화

## 1. Define sweep configuration
- early_terminate 추가
## 2. Result
- [wandb sweep report](https://api.wandb.ai/links/sinjy1203/yyoxrldp)
</br>

# gif product image encoding
- 상품 이미지로 썸네일 이미지를 사용함
- 썸네일 이미지가 gif인 경우가 있음
  => gif를 여러개의 이미지로 나누고 각 이미지의 임베딩 값의 평균을 vector DB에 저장
## 1. gif -> 여러개의 이미지로 분할
```python
image_obj = Image.open(BytesIO(obj))
if isinstance(image_obj, PIL.GifImagePlugin.GifImageFile): # gif인지 jpg인지 확인
    imgs_lst = []
    for i in range(image_obj.n_frames): # gif의 frame 수만큼 반복
        image_obj.seek(i)
        imgs_lst.append(preprocess(image_obj.convert("RGB"))) # 각 frame을 jpg로 변환후 imgs_lst에 추가
    return torch.stack(imgs_lst, dim=0), image_obj.n_frames # tensor로 변환
```
## 2. 여러개의 이미지를 하나의 tensor로 합치기
- jpg와 gif가 섞여서 들어올 수 있음 -> jpg는 frame이 1개이고 gif는 여러개
- 하나의 tensor로 합치기 전에 각 frame 개수 정보를 얻음 -> 이 정보를 사용해 어떤 상품의 이미지들인지 확인
```python
imgs_tensor, nframes = asyncio.run(
    s3.load_img(products_df["URL"].to_list(), product_encode_preprocess)
)
```
ex) 
  - imgs_tensor의 size가 (8, 3, 128, 128)이고 nframes = [2, 1, 1, 3, 1]
  - 상품개수는 5개이지만 0, 3 index의 상품은 gif라 nframe이 각각 2, 3개
## 3. 예측한 상품 임베딩 벡터들을 상품에 따라 평균으로 계산 후에 vectorDB에 저장
```python
def mean_nframe_encoded(imgs_encoded, nframes):
    new_imgs_encoded = []
    start_idx = 0
    for nframe in nframes:
        end_idx = start_idx + nframe
        sub_tensor = imgs_encoded[start_idx:end_idx]
        mean_tensor = torch.mean(sub_tensor, dim=0, keepdim=True)
        new_imgs_encoded.append(mean_tensor)
        start_idx = end_idx
    return torch.cat(new_imgs_encoded, dim=0)
```
</br>

# product encode error
- 전체 상품을 한번에 임베딩할려고 했더니 에러 발생
`aiohttp.client_exceptions.ServerDisconnectedError: Server disconnected`
  - local에서는 에러가 발생하지 않아서 원인 찾기 어려웠음
- cpu 사용률이 거의 100%를 찍는 것을 확인
  => 한번에 많은 양의 데이터를 처리하면 안된다...
  => 모든 상품을 임베딩할 때 batch로 나누어서 실행
```python
imgs_encoded = []
for i in range(imgs_tensor.shape[0] // 16 + 1):
    imgs_encoded.append(
        product_encode_runner.run(imgs_tensor[i * 16 : (i + 1) * 16])
    )
imgs_encoded = torch.cat(imgs_encoded, dim=0)
```
</br>

# 상품 임베딩 시각화
- 실제 상품에 대한 임베딩이 잘 되는지 확인해볼 필요가 있음
- 상품DB와 vectorDB를 wandb로 시각화해서 확인
- [wandb projector](https://wandb.ai/sinjy1203/product_embedding_visualization/reports/product-image-embedding-vector-projector--Vmlldzo1NDI0MzMy?accessToken=4959zhp7eyy164rwt63if8r0tk7uxwc0c7406f0phkdhyu3xe0abyrck1pnzhszb)
